### PR TITLE
Implements pessimistic locker

### DIFF
--- a/lib/rails_event_store_mongoid.rb
+++ b/lib/rails_event_store_mongoid.rb
@@ -1,4 +1,5 @@
 require 'rails_event_store/all'
+require 'rails_event_store_mongoid/locker'
 require 'rails_event_store_mongoid/event'
 require 'rails_event_store_mongoid/event_repository'
 require 'rails_event_store_mongoid/version'

--- a/lib/rails_event_store_mongoid/lock.rb
+++ b/lib/rails_event_store_mongoid/lock.rb
@@ -1,0 +1,20 @@
+require 'mongoid'
+
+module RailsEventStoreMongoid
+  class Lock
+    include Mongoid::Document
+
+    store_in collection: 'event_store_locks'
+
+    field :_id, type: String, default: ->{ SecureRandom.uuid }, overwrite: true
+    field :ts, type: Time
+
+    def with_lock(stream)
+      lock = self.class.create(_id: stream, ts: Time.now.utc)
+      yield if block_given?
+      lock.delete
+    end
+
+    index({ ts: 1 }, { expire_after_seconds: 30 })
+  end
+end

--- a/lib/rails_event_store_mongoid/locker.rb
+++ b/lib/rails_event_store_mongoid/locker.rb
@@ -1,0 +1,17 @@
+require 'rails_event_store_mongoid/lock'
+
+module RailsEventStoreMongoid
+  class Locker
+
+    def initialize(adapter: ::RailsEventStoreMongoid::Lock.new)
+      @adapter = adapter
+    end
+
+    def with_lock(stream, &block)
+      @adapter.with_lock(stream, &block)
+    rescue ::Mongo::Error::OperationFailure => exception
+      raise ::RailsEventStore::CannotObtainLock
+    end
+
+  end
+end

--- a/spec/mongoid.yml
+++ b/spec/mongoid.yml
@@ -1,0 +1,13 @@
+test:
+  clients:
+    default:
+      database: rails_event_store_mongoid_test
+      hosts:
+        - localhost:27017
+      options:
+        read:
+          mode: :primary
+        write:
+          w: 1
+  options:
+    use_utc: true

--- a/spec/rails_event_store_mongoid/locker_spec.rb
+++ b/spec/rails_event_store_mongoid/locker_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe RailsEventStoreMongoid::Locker do
+
+  let(:locker) { described_class.new }
+  let(:event) { RubyEventStore::Event.new }
+  let(:event_repository) { RailsEventStoreMongoid::EventRepository.new }
+  let(:aggregate_id) { SecureRandom.uuid }
+
+  context 'when not using a lock' do
+
+    before do
+      2.times.map do
+        Thread.new do
+          event_repository.create(event, aggregate_id)
+        end
+      end.each(&:join)
+    end
+
+    it 'stores 2 times the event' do
+      expect(event_repository.read_stream_events_forward(aggregate_id).count).to eq(2)
+    end
+
+  end
+
+  context 'when using a lock' do
+
+    def store
+      2.times.map do
+        Thread.new do
+          locker.with_lock(aggregate_id) do
+            event_repository.create(event, aggregate_id)
+          end
+        end
+      end.each(&:join)
+    end
+
+    let(:locker) { described_class.new }
+
+    it 'raises and stores 1 time the event' do
+      expect { store }.to raise_error(RubyEventStore::CannotObtainLock)
+      expect(event_repository.read_stream_events_forward(aggregate_id).count).to eq(1)
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rails_event_store_mongoid'
+
+Mongoid.load!("spec/mongoid.yml", :test)
+
+RSpec.configure do |config|
+  config.before :example do
+    Mongoid.purge!
+  end
+end


### PR DESCRIPTION
Overview

This changes allow to perform a database lock per aggregates in order to avoid concurrency issues in a concurrent environment, such as, multi-threaded env or load balanced event store (multiple event store processes trying to create events on the database at the same time).

The lock only blocks the aggregate, not the entire event table. A RubyEventStore::CannotObtainLock exception is raised in case the lock could not be obtained. Meaning an event store was already trying to perform an INSERT on the given aggregate.

From a client perspective, a good place to catch this exception is when loading the events in the aggregate:

```ruby
module CommandHandlers
  class Base
    def with_aggregate(aggregate_id, aggregate_class:)
      aggregate = build(aggregate_id, aggregate_class)
      yield aggregate
      aggregate.store(aggregate_id, event_store: event_store)
    rescue ::RubyEventStore::CannotObtainLock
      retry
    end

    def build(aggregate_id, aggregate_class)
      aggregate_class.new(aggregate_id).tap do |aggregate|
        aggregate.load(aggregate_id, event_store: event_store)
      end
    end
  end
end
```

This way a client can ensure latest events are loaded in the aggregate.