### PR TITLE
Order events by creation date not id.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.3.3
+
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker-compose build
+
+script:
+  - docker-compose up -d
+  - rspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+
+services:
+  mongo:
+    container_name: rails_event_store_mongo
+    image: mongo:3.2
+    command: ["--storageEngine", "wiredTiger"]
+    ports:
+      - "27027:27017"
+    logging:
+      driver: json-file
+      options:
+        max-size: '10k'
+        max-file: '3'
+

--- a/lib/rails_event_store_mongoid/event.rb
+++ b/lib/rails_event_store_mongoid/event.rb
@@ -13,7 +13,9 @@ module RailsEventStoreMongoid
     field :meta, type: Hash, default: {}
     field :data, type: Hash, default: {}
 
+    field :ts, type: BSON::Timestamp, default: -> { BSON::Timestamp.new(0, 0) }
+
     index(event_id: 1)
-    index(stream: 1, _id: 1)
+    index(stream: 1, ts: 1)
   end
 end

--- a/lib/rails_event_store_mongoid/event_repository.rb
+++ b/lib/rails_event_store_mongoid/event_repository.rb
@@ -27,17 +27,17 @@ module RailsEventStoreMongoid
     end
 
     def last_stream_event(stream_name)
-      build_event_entity(adapter.where(stream: stream_name).desc(:id).first)
+      build_event_entity(adapter.where(stream: stream_name).desc(:ts).first)
     end
 
     def read_events_forward(stream_name, start_event_id, count)
       stream = adapter.where(stream: stream_name)
       unless start_event_id.equal?(:head)
         starting_event = adapter.find_by(event_id: start_event_id)
-        stream = stream.where(:id.gt => starting_event.id)
+        stream = stream.where(:ts.gt => starting_event.ts)
       end
 
-      stream.asc(:id).limit(count)
+      stream.asc(:ts).limit(count)
         .map(&method(:build_event_entity))
     end
 
@@ -45,20 +45,20 @@ module RailsEventStoreMongoid
       stream = adapter.where(stream: stream_name)
       unless start_event_id.equal?(:head)
         starting_event = adapter.find_by(event_id: start_event_id)
-        stream = stream.where(:id.lt => starting_event.id)
+        stream = stream.where(:ts.lt => starting_event.ts)
       end
 
-      stream.desc(:id).limit(count)
+      stream.desc(:ts).limit(count)
         .map(&method(:build_event_entity))
     end
 
     def read_stream_events_forward(stream_name)
-      adapter.where(stream: stream_name).asc(:id)
+      adapter.where(stream: stream_name).asc(:ts)
         .map(&method(:build_event_entity))
     end
 
     def read_stream_events_backward(stream_name)
-      adapter.where(stream: stream_name).desc(:id)
+      adapter.where(stream: stream_name).desc(:ts)
         .map(&method(:build_event_entity))
     end
 
@@ -66,10 +66,10 @@ module RailsEventStoreMongoid
       stream = adapter
       unless start_event_id.equal?(:head)
         starting_event = adapter.find_by(event_id: start_event_id)
-        stream = stream.where(:id.gt => starting_event.id)
+        stream = stream.where(:ts.gt => starting_event.ts)
       end
 
-      stream.asc(:id).limit(count)
+      stream.asc(:ts).limit(count)
         .map(&method(:build_event_entity))
     end
 
@@ -77,10 +77,10 @@ module RailsEventStoreMongoid
       stream = adapter
       unless start_event_id.equal?(:head)
         starting_event = adapter.find_by(event_id: start_event_id)
-        stream = stream.where(:id.lt => starting_event.id)
+        stream = stream.where(:ts.lt => starting_event.ts)
       end
 
-      stream.desc(:id).limit(count)
+      stream.desc(:ts).limit(count)
         .map(&method(:build_event_entity))
     end
 

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -1,0 +1,6 @@
+test:
+  clients:
+    default:
+      database: rails_event_store_mongoid_test
+      hosts:
+        - localhost:27027

--- a/spec/rails_event_store_mongoid/event_repository_spec.rb
+++ b/spec/rails_event_store_mongoid/event_repository_spec.rb
@@ -18,4 +18,60 @@ describe RailsEventStoreMongoid::EventRepository do
     expect(repository.adapter).to eq(CustomEvent)
   end
 
+  describe 'event ordering' do
+    let(:stream_name) { 'test_stream' }
+
+    class SimpleEvent
+      attr_reader :event_id
+      def initialize(event_id: SecureRandom.uuid, metadata: nil, data: nil)
+        @event_id = event_id.to_i
+      end
+    end
+
+    def create_event(event_id:, stream: stream_name)
+      internal = { event_type: 'SimpleEvent', stream: stream }
+      RailsEventStoreMongoid::Event.create!(
+                       internal.merge(event_id: event_id, id: event_id)
+      )
+    end
+
+    before do
+      create_event(event_id: 2)
+      create_event(event_id: 1)
+
+      create_event(event_id: 20, stream: 'other_stream')
+
+      create_event(event_id: 4)
+      create_event(event_id: 3)
+
+    end
+
+    specify '#last_stream_event' do
+      expect(subject.last_stream_event(stream_name).event_id).to eq(3)
+    end
+
+    specify '#read_events_forward' do
+      expect(subject.read_events_forward(stream_name, 1, 5).map(&:event_id)).to eq([4,3])
+    end
+
+    specify '#read_events_backward' do
+      expect(subject.read_events_backward(stream_name, 4, 5).map(&:event_id)).to eq([1,2])
+    end
+
+    specify '#read_stream_events_forward' do
+      expect(subject.read_stream_events_forward(stream_name).map(&:event_id)).to eq([2,1,4,3])
+    end
+
+    specify '#read_stream_events_backward' do
+      expect(subject.read_stream_events_backward(stream_name).map(&:event_id)).to eq([3,4,1,2])
+    end
+
+    specify '#read_all_streams_backward' do
+      expect(subject.read_all_streams_backward(4, 5).map(&:event_id)).to eq([20,1,2])
+    end
+
+    specify '#read_all_streams_forward' do
+      expect(subject.read_all_streams_forward(1, 5).map(&:event_id)).to eq([20,4,3])
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,11 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rails_event_store_mongoid'
+require 'pry'
+
+Mongoid.load!('./spec/config/mongoid.yml', 'test')
+
+RSpec.configure do |config|
+  config.before do
+    Mongoid.purge!
+  end
+end


### PR DESCRIPTION
MongoDB IDs are not guaranteed to be monotonic if subsequent records are created the same second
(http://stackoverflow.com/a/24886642/580346). To maintain correct event order we need to sort using created_at field.